### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/AllenDang/safe_format/compare/v0.1.0...v0.1.1) - 2024-07-09
+
+### Other
+- release
+
 ## [0.1.0](https://github.com/AllenDang/safe_format/releases/tag/v0.1.0) - 2024-07-09
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe_format"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Allen Dang <allengnr@gmail.com>"]
 edition = "2021"
 description = "safe_format! macro works similarly to the built-in format! macro but allows for named parameters and it safely ignores any extra parameters that are not used in format string"


### PR DESCRIPTION
## 🤖 New release
* `safe_format`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/AllenDang/safe_format/compare/v0.1.0...v0.1.1) - 2024-07-09

### Other
- release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).